### PR TITLE
Add repo url documentation and handle stratum0 failures.

### DIFF
--- a/config.ini.example
+++ b/config.ini.example
@@ -3,6 +3,8 @@ title=EESSI status!
 logging_level=WARN
 min_ok_stratum1=2
 contact_email=support@eessi.io
+repo_url=https://github.com/eessi
+repo_url_text=EESSI @ github
 
 [stratum0]
 rug-nl-s0.eessi.science

--- a/create_status_page.py
+++ b/create_status_page.py
@@ -46,6 +46,10 @@ def read_config(file_path: str) -> Dict[str, List[str]]:
         "min_ok_stratum1": config.getint("config", "min_ok_stratum1", fallback=2),
         "contact_email": config.get("config", "contact_email", fallback=""),
         "title": config.get("config", "title", fallback="EESSI :: Status"),
+        "repo_url": config.get("config", "repo_url", fallback=""),
+        "repo_url_text": config.get(
+            "config", "repo_url_text", fallback="Repository documentation"
+        ),
     }
 
     for section in CONFIG_SECTIONS_THAT_MUST_HAVE_VALUES:
@@ -217,6 +221,15 @@ for server in servers:
             repo_snap_status[repo.name] = default_class
             known_repos[repo.name] = 1
 
+            if repo.name not in stratum0_repo_versions:
+                stratum0_name = config["stratum0_servers"][0]
+                # We did not get a repo from stratum0, this is bad.
+                repo_rev_status[repo.name] = warning_class()
+                eessi_status_text = "Stratum0 not responding!"
+                eessi_status_class = get_class("WARNING")
+                eessi_status_description = f"Due to stratum0 ({stratum0_name}) not responding, status for repositories and their versions cannot be validated."
+                continue
+
             if repo.revision != stratum0_repo_versions[repo.name]:
                 updates = warning_class()
                 eessi_not_ok_events.append(2)
@@ -302,6 +315,8 @@ data: Dict[str, Any] = {
     "last_update": datetime.now(tz=timezone.utc).strftime("%Y-%m-%d %H:%M:%S %Z"),
     "contact_email": config["contact_email"],
     "title": config["title"],
+    "repo_url": config["repo_url"],
+    "repo_url_text": config["repo_url_text"],
 }
 
 output = template.render(data)

--- a/templates/status.html.j2
+++ b/templates/status.html.j2
@@ -107,7 +107,11 @@
     </div>
 </div>
 
-<div class="footer">Last updated {{ last_update }} | {{ contact_email }}</div>
+<div class="footer">Last updated {{ last_update }}
+{% if repo_url -%}
+   | <a href="{{ repo_url }}">{{ repo_url_text }}</a>
+{% endif %}
+| {{ contact_email }}</div>
 
 </body>
 </html>


### PR DESCRIPTION
  - Allow for setting `repo_url` (defaults to None) and `repo_url_text` (defaults"Repository documentation") in the config.
  - Iff `repo_url` is set, create a link in the center of the footer pointing to `repo_url` with `repo_url_text` as the link text.
  - Also handles the situation where the scraper fails to get repos from stratum0 for any reason.

Fixes #4, Fixes #6.